### PR TITLE
fix: align tour map modal's close button to right

### DIFF
--- a/Resources/views/tours/show.blade.php
+++ b/Resources/views/tours/show.blade.php
@@ -145,7 +145,7 @@
     <div class="modal fade" id="staticBackdrop" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
       <div class="modal-dialog modal-dialog-xxl mx-auto" style="width: 80vw; min-width: 80vw">
         <div class="modal-content">
-          <div class="modal-header p-1 border-0">
+          <div class="modal-header p-1 border-0 flex justify-content-between">
             <h5 class="m-1" id="staticBackdropLabel">
               @lang('DSpecial::tours.tmap')
             </h5>


### PR DESCRIPTION
A super-small modification to align _close button_ of the tours map modal to right top.

From `| Tour X        |` to `| Tour <-----> X |`

Uses standard bootstrap classes. I can re-do with a style tag if needed.